### PR TITLE
Issue6（予約一覧・詳細画面の終了時間修正）

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -2,9 +2,13 @@ class ReservationsController < ApplicationController
   def index
     @studios = Studio.includes(:admin)
     @reservations = Reservation.all.order(time_from_id: 'ASC')
+    @reservations.each do |reservation|
+      reservation.time_to_id += 1
+    end
   end
 
   def show
     @reservation = Reservation.find(params[:id])
+    @reservation.time_to_id += 1
   end
 end

--- a/app/models/time_list.rb
+++ b/app/models/time_list.rb
@@ -13,6 +13,7 @@ class TimeList < ActiveHash::Base
     { id: 10, name: '19:00' }, # 19~20時
     { id: 11, name: '20:00' }, # 20~21時
     { id: 12, name: '21:00' }, # 21~22時
-    { id: 13, name: '22:00' }
+    { id: 13, name: '22:00' },
+    { id: 14, name: '22:00' }
   ]
 end

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -24,7 +24,6 @@
       <% reservation.each do |i| %>
         <div>
           <%= link_to Studio.find_by(id: i.reserve.studio_id).name, reservation_path(i.id), class: "test" %>
-          <%#= f = Studio.find_by(id: i.reserve.studio_id).name %>
           <%= g = TimeList.find_by(id: i.time_from_id).name %> ~
           <%= h = TimeList.find_by(id: i.time_to_id).name %>
         </div>


### PR DESCRIPTION
# what
予約一覧・予約詳細機能における終了時間表示の修正

# why
現状、テーブルから抜き出した情報のままでは実際に予約した時間よりも1時間短く表示されているため