### PR TITLE
Issue8（スタジオ編集画面のヘッダー文）の解消

### DIFF
--- a/app/views/studios/edit.html.erb
+++ b/app/views/studios/edit.html.erb
@@ -7,7 +7,7 @@
     <%# 入力欄のヘッダー %>
       <div class='form-header-2'>
         <h1 class='form-header-text-2'>
-          スタジオ追加
+          スタジオ編集
         </h1>
       </div>
       <%# /入力欄のヘッダー %>


### PR DESCRIPTION
# what
スタジオ編集画面のヘッダー文を以下の通り修正
誤：スタジオ追加
正：スタジオ編集

# why
画面での実施内容とヘッダー文に相違があるため